### PR TITLE
pbrd: fix null pointer deref when showing ifaces

### DIFF
--- a/pbrd/pbr_map.c
+++ b/pbrd/pbr_map.c
@@ -163,7 +163,8 @@ void pbr_map_write_interfaces(struct vty *vty, struct interface *ifp)
 {
 	struct pbr_interface *pbr_ifp = ifp->info;
 
-	if (!(strcmp(pbr_ifp->mapname, "") == 0))
+	if (pbr_ifp
+	    && strncmp(pbr_ifp->mapname, "", sizeof(pbr_ifp->mapname)) != 0)
 		vty_out(vty, " pbr-policy %s\n", pbr_ifp->mapname);
 }
 


### PR DESCRIPTION
If there are no PBR interfaces configured and we do a 'show run', pbrd
crashes with a NPD when it tries to dereference ifp->info.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>