### PR TITLE
Fix nhg extraspace

### DIFF
--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -361,8 +361,10 @@ static int nexthop_group_write(struct vty *vty)
 	RB_FOREACH (nhgc, nhgc_entry_head, &nhgc_entries) {
 		vty_out(vty, "nexthop-group %s\n", nhgc->name);
 
-		for (nh = nhgc->nhg.nexthop; nh; nh = nh->next)
+		for (nh = nhgc->nhg.nexthop; nh; nh = nh->next) {
+			vty_out(vty, "  ");
 			nexthop_group_write_nexthop(vty, nh);
+		}
 
 		vty_out(vty, "!\n");
 	}

--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -320,7 +320,7 @@ void nexthop_group_write_nexthop(struct vty *vty, struct nexthop *nh)
 	char buf[100];
 	struct vrf *vrf;
 
-	vty_out(vty, "  nexthop ");
+	vty_out(vty, "nexthop ");
 
 	switch (nh->type) {
 	case NEXTHOP_TYPE_IFINDEX:

--- a/pbrd/pbr_nht.c
+++ b/pbrd/pbr_nht.c
@@ -771,7 +771,7 @@ static void pbr_nht_show_nhg_nexthops(struct hash_backet *b, void *data)
 	struct pbr_nexthop_cache *pnhc = b->data;
 	struct vty *vty = data;
 
-	vty_out(vty, "\tValid: %d", pnhc->valid);
+	vty_out(vty, "\tValid: %d ", pnhc->valid);
 	nexthop_group_write_nexthop(vty, pnhc->nexthop);
 }
 

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -544,8 +544,7 @@ static int pbr_vty_map_config_write_sequence(struct vty *vty,
 {
 	char buff[PREFIX_STRLEN];
 
-	vty_out(vty, "pbr-map %s seq %u\n",
-		pbrm->name, pbrms->seqno);
+	vty_frame(vty, "pbr-map %s seq %u\n", pbrm->name, pbrms->seqno);
 
 	if (pbrms->src)
 		vty_out(vty, "  match src-ip %s\n",
@@ -559,11 +558,11 @@ static int pbr_vty_map_config_write_sequence(struct vty *vty,
 		vty_out(vty, "  set nexthop-group %s\n", pbrms->nhgrp_name);
 
 	if (pbrms->nhg) {
-		vty_out(vty, "  set");
+		vty_out(vty, "  set ");
 		nexthop_group_write_nexthop(vty, pbrms->nhg->nexthop);
 	}
 
-	vty_out(vty, "!\n");
+	vty_endframe(vty, "!\n");
 	return 1;
 }
 


### PR DESCRIPTION
I also used `vty_frame` for `pbr-map` config so we don't display the map name if it has no child config, if it shouldn't work this way then ill edit it out