### PR TITLE
PR-6725 pim msdp cleanup and commits

### DIFF
--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -330,10 +330,10 @@ caution. Most of the time this will not be necessary.
    Insert into the Multicast Rib Route A.B.C.D/M using the specified INTERFACE.
    The distance can be specified as well if desired.
 
-.. _msdp-configuration
+.. _msdp-configuration:
 
 Multicast Source Discovery Protocol (MSDP) Configuration
-====================
+========================================================
 
 .. index:: ip msdp mesh-group [WORD] member A.B.C.D
 .. clicmd:: ip msdp mesh-group [WORD] member A.B.C.D

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -423,7 +423,6 @@ void pim_msdp_sa_ref(struct pim_instance *pim, struct pim_msdp_peer *mp,
 					   sa->sg_str);
 			}
 			/* send an immediate SA update to peers */
-			sa->rp = pim->msdp.originator_id;
 			pim_msdp_pkt_sa_tx_one(sa);
 		}
 		sa->flags &= ~PIM_MSDP_SAF_STALE;

--- a/pimd/pim_msdp_packet.c
+++ b/pimd/pim_msdp_packet.c
@@ -444,7 +444,8 @@ void pim_msdp_pkt_sa_tx(struct pim_instance *pim)
 
 void pim_msdp_pkt_sa_tx_one(struct pim_msdp_sa *sa)
 {
-	pim_msdp_pkt_sa_fill_hdr(sa->pim, 1 /* cnt */, sa->rp);
+	pim_msdp_pkt_sa_fill_hdr(sa->pim, 1 /* cnt */,
+				 sa->pim->msdp.originator_id);
 	pim_msdp_pkt_sa_fill_one(sa);
 	pim_msdp_pkt_sa_push(sa->pim, NULL);
 	pim_msdp_pkt_sa_tx_done(sa->pim);
@@ -457,8 +458,8 @@ void pim_msdp_pkt_sa_tx_to_one_peer(struct pim_msdp_peer *mp)
 	pim_msdp_pkt_sa_tx_done(mp->pim);
 }
 
-void pim_msdp_pkt_sa_tx_one_to_one_peer(struct pim_msdp_peer *mp,
-					struct in_addr rp, struct prefix_sg sg)
+void pim_msdp_pkt_sa_forward(struct pim_msdp_peer *mp, struct in_addr rp,
+			     struct prefix_sg sg)
 {
 	struct pim_msdp_sa sa;
 
@@ -525,7 +526,7 @@ static void pim_msdp_pkt_sa_rx_one(struct pim_msdp_peer *mp, struct in_addr rp)
 		if (!pim_msdp_peer_rpf_check(peer, rp)
 		    && (strcmp(mp->mesh_group_name, peer->mesh_group_name)
 			|| !strcmp(mp->mesh_group_name, "default"))) {
-			pim_msdp_pkt_sa_tx_one_to_one_peer(peer, rp, sg);
+			pim_msdp_pkt_sa_forward(peer, rp, sg);
 		}
 	}
 }

--- a/pimd/pim_msdp_packet.h
+++ b/pimd/pim_msdp_packet.h
@@ -67,7 +67,7 @@ int pim_msdp_read(struct thread *thread);
 void pim_msdp_pkt_sa_tx(struct pim_instance *pim);
 void pim_msdp_pkt_sa_tx_one(struct pim_msdp_sa *sa);
 void pim_msdp_pkt_sa_tx_to_one_peer(struct pim_msdp_peer *mp);
-void pim_msdp_pkt_sa_tx_one_to_one_peer(struct pim_msdp_peer *mp,
-					struct in_addr rp, struct prefix_sg sg);
+void pim_msdp_pkt_sa_forward(struct pim_msdp_peer *mp, struct in_addr rp,
+			     struct prefix_sg sg);
 
 #endif


### PR DESCRIPTION
I addressed the comments from @AnuradhaKaruppiah:
* Renamed the function pim_msdp_pkt_sa_tx_one_to_one_peer to pim_msdp_pkt_forward_sa.
* Modified the function pim_msdp_pkt_sa_tx_one to the RP is always the originator.
* Fixed documentation warnings.
  